### PR TITLE
Add responsiveness to vega charts

### DIFF
--- a/layouts/shortcodes/viz.html
+++ b/layouts/shortcodes/viz.html
@@ -10,9 +10,19 @@
 		{{ $dataJ := getJSON $url }}
 		vizSpec = {{$dataJ}};
 		opt = { mode: {{$vizmode}}, actions: false };
+		var width, clientWidth;
 		{{ if .Get "width" }}
-			opt['width'] = {{ .Get "width" }};
+			width = parseInt({{ .Get "width" }});
 		{{ end }}
+		clientWidth = document.getElementById('{{replace (.Get "id") "#" "" }}').clientWidth;
+		if(clientWidth < width) {
+			width = clientWidth;
+		}
+		vizSpec['width'] = width;
+		vizSpec["autosize"] = {
+			"type": "fit",
+			"contains": "padding"
+		};
 		vegaEmbed('{{.Get "id"}}', vizSpec, opt, function(error, result) {
 				return;
 		});


### PR DESCRIPTION
in addition to the setting of width via shortcode do not make charts
bigger than the parent element
use vega fit to make sure it does not overflow
might need better label handling for larger labels