### PR TITLE
Add subscribe form and move survey to this folder

### DIFF
--- a/assets/scss/civic.scss
+++ b/assets/scss/civic.scss
@@ -85,3 +85,38 @@ form#survey {
 #survey-response {
 	visibility: hidden;
 }
+form#ck-simple {
+	font-size: 16px;
+	font-weight: 400;
+	margin: 2rem 0;
+	padding: 0 0 2rem 0;
+	input {
+		font-size: 16px;
+		border-radius: .25rem;
+		line-height: 1.25;
+		padding: .5rem 0.75rem;
+		box-shadow: 0 2px 4px 0 rgba(0,0,0,.1);
+		color: #606f7b;
+		margin-bottom: 1rem;
+		max-width: 20rem;
+		width: 100%;
+		border: 1px solid #dae1e7;
+	}
+	.btn {
+		border-radius: .25rem;
+		background-color: #3490dc;
+		padding: .5rem 1rem;
+		color: #fff;
+		font-size: 16px;
+		cursor: pointer;
+	}
+	.btn:hover {
+		background-color: #2779bd;
+	}
+	p {
+		margin-top: 0;
+	}
+	.small {
+		font-size: 0.75rem;
+	}
+}

--- a/content/subscribe/_index.md
+++ b/content/subscribe/_index.md
@@ -1,0 +1,14 @@
+---
+type: "static"
+form: {
+	id: 829240,
+	before_button: "<span class='small'>I won't SPAM you, promised!</span>",
+	fields: [
+		{ id: "name", placeholder: "Your name", name: "fields[first_name]", type: "text" },
+		{ id: "email", placeholder: "Your email address", name: "email_address", type: "email" },
+	]
+}
+---
+# Get updates about Civic Tech, Open Data and Open Government
+
+{{< form >}}

--- a/content/subscribe/survey.md
+++ b/content/subscribe/survey.md
@@ -1,7 +1,10 @@
 ---
 title: Thank you for subscribing - I want to get to know you better!
+type: "static"
 ---
-Thanks for subscribing to the Civic Open Data Newsletter. I email you weekly with the latest in Civic tech, Open Data and Open Government.
+Thanks for subscribing to the Civic Open Data Newsletter.  
+_Check your email, you need to confirm your subscription._  
+I email you at least weekly with the latest in Civic Tech, Open Data and Open Government.
 
 To get to know you a little better I would love if you could fill out this short survey. 
 All answers are optional but I would love to get to know you as best as possible.  

--- a/layouts/partials/form.ace
+++ b/layouts/partials/form.ace
@@ -1,0 +1,14 @@
+script src="https://f.convertkit.com/ckjs/ck.5.js"
+form#ck-simple action="https://app.convertkit.com/forms/{{.id}}/subscriptions" method="post" data-sv-form="{{.id}}" data-uid="13ac36f026" data-format="inline" data-version="5" data-options="{&quot;settings&quot;:{&quot;after_subscribe&quot;:{&quot;action&quot;:&quot;message&quot;,&quot;redirect_url&quot;:&quot;&quot;,&quot;success_message&quot;:&quot;Success! Now check your email to confirm your subscription.&quot;},&quot;return_visitor&quot;:{&quot;action&quot;:&quot;show&quot;,&quot;custom_content&quot;:&quot;&quot;},&quot;recaptcha&quot;:{&quot;enabled&quot;:false}}}"
+  div data-style="clean"
+  ul.formkit-alert.formkit-alert-error data-element="errors" data-group="alert"
+  {{ range .fields }}
+    .seva-fields.formkit-fields data-element="fields" data-stacked="false"
+      .formkit-field
+        input.formkit-input id="{{.id}}" placeholder="{{.placeholder}}" type="{{.type}}" name="{{.name}}"
+  {{ end }}
+  .formkit-spinner
+  {{ if .before_button }}
+    p {{ .before_button | safeHTML }}
+  {{ end }}
+  button.btn data-element="submit" Subscribe

--- a/layouts/partials/survey.ace
+++ b/layouts/partials/survey.ace
@@ -31,7 +31,7 @@ form#survey onsubmit="event.preventDefault(); sendSurveyResponse('survey');"
 
   fieldset
     label.legend for="excited-area" 
-      | What is the most exciting area within 
+      | What is the most exciting area for you within 
       span#one-question-topic Civic Tech/Open Data/Open Government
     textarea name="excited-area" id="exciting-area" rows=5
 
@@ -44,14 +44,17 @@ form#survey onsubmit="event.preventDefault(); sendSurveyResponse('survey');"
       input type="radio" id="every_day" name="use_dataviz" value="Every Day"
       label for="every_day" Every Day
     .row
+      input type="radio" id="use_every_week" name="use_dataviz" value="Every Week"
+      label for="use_every_week" Every Week
+    .row
       input type="radio" id="time-to-time" name="use_dataviz" value="Time to time"
       label for="every_day" From time to time
     .row
       input type="radio" id="interested" name="use_dataviz" value="Interested"
-      label for="every_day" I'm interested in data visualization
+      label for="every_day" I'm interested in using data visualization
     .row
       input type="radio" id="not-interested" name="use_dataviz" value="Not Interested"
-      label for="every_day" I'm not interested in data visualization
+      label for="every_day" I'm not interested in using data visualization
 
   fieldset
     legend
@@ -62,14 +65,17 @@ form#survey onsubmit="event.preventDefault(); sendSurveyResponse('survey');"
       input type="radio" id="create_every_day" name="create_dataviz" value="Every Day"
       label for="create_every_day" Every Day
     .row
+      input type="radio" id="create_every_week" name="create_dataviz" value="Every Week"
+      label for="create_every_week" Every Week
+    .row
       input type="radio" id="create_time-to-time" name="create_dataviz" value="Time to time"
       label for="create_time-to-time" From time to time
     .row
       input type="radio" id="create_interested" name="create_dataviz" value="Interested"
-      label for="create_interested" I'm interested in data visualization
+      label for="create_interested" I'm interested in creating data visualization
     .row
       input type="radio" id="create_not-interested" name="create_dataviz" value="Not Interested"
-      label for="create_not-interested" I'm not interested in data visualization
+      label for="create_not-interested" I'm not interested in creating data visualization
 
   button type="submit" Submit
 #survey-response Thank you for filling out the survey. Have a great day!

--- a/layouts/shortcodes/form.html
+++ b/layouts/shortcodes/form.html
@@ -1,0 +1,1 @@
+{{ partial "form" .Page.Params.form }}

--- a/layouts/static/single.html
+++ b/layouts/static/single.html
@@ -1,0 +1,16 @@
+{{ define "header" }}
+	{{ partial "page-single/variables-init.html" . }}
+	{{ partial "header.html" . }}
+{{ end }}
+
+{{ define "content" }}
+  <div class="static">
+    <h1>{{ .Title }}</h1>
+    {{ .Content }}
+  </div>
+{{ end }}
+
+{{ define "footer" }}
+	{{ partial "page-single/footer.html" . }}
+	{{ partial "page-single/variables-deinit.html" . }}
+{{ end }}


### PR DESCRIPTION
We need a own form to really use the subscriber_id field with
rightmessage, maybe a thank you page would be enough, but this way it is
more consistent
add a static type that does not include all the sugar for posts
add a form shotcode that uses the page form frontmatter to construct the
form, currently just for convertkit, maybe I adjust this later
update the survey with more options for using and creating.