### PR TITLE
Add custom convertkit options to frontmatter

### DIFF
--- a/content/subscribe/_index.md
+++ b/content/subscribe/_index.md
@@ -6,7 +6,11 @@ form: {
 	fields: [
 		{ id: "name", placeholder: "Your name", name: "fields[first_name]", type: "text" },
 		{ id: "email", placeholder: "Your email address", name: "email_address", type: "email" },
-	]
+	],
+	data: {
+		uid: "cd30502d06",
+		options: "{&quot;settings&quot;:{&quot;after_subscribe&quot;:{&quot;action&quot;:&quot;redirect&quot;,&quot;success_message&quot;:&quot;Success! Now check your email to confirm your subscription.&quot;,&quot;redirect_url&quot;:&quot;https://civicopendata.com/subscribe/survey/&quot;},&quot;modal&quot;:{&quot;trigger&quot;:null,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:null,&quot;devices&quot;:null,&quot;show_once_every&quot;:null},&quot;recaptcha&quot;:{&quot;enabled&quot;:false},&quot;return_visitor&quot;:{&quot;action&quot;:&quot;custom_content&quot;,&quot;custom_content&quot;:&quot;You already subscribed. Missing some email? Check you spam folder. &quot;},&quot;slide_in&quot;:{&quot;display_in&quot;:null,&quot;trigger&quot;:null,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:null,&quot;devices&quot;:null,&quot;show_once_every&quot;:null}}}"
+	}
 }
 ---
 # Get updates about Civic Tech, Open Data and Open Government

--- a/layouts/partials/form.ace
+++ b/layouts/partials/form.ace
@@ -1,5 +1,5 @@
 script src="https://f.convertkit.com/ckjs/ck.5.js"
-form#ck-simple action="https://app.convertkit.com/forms/{{.id}}/subscriptions" method="post" data-sv-form="{{.id}}" data-uid="13ac36f026" data-format="inline" data-version="5" data-options="{&quot;settings&quot;:{&quot;after_subscribe&quot;:{&quot;action&quot;:&quot;message&quot;,&quot;redirect_url&quot;:&quot;&quot;,&quot;success_message&quot;:&quot;Success! Now check your email to confirm your subscription.&quot;},&quot;return_visitor&quot;:{&quot;action&quot;:&quot;show&quot;,&quot;custom_content&quot;:&quot;&quot;},&quot;recaptcha&quot;:{&quot;enabled&quot;:false}}}"
+form#ck-simple action="https://app.convertkit.com/forms/{{.id}}/subscriptions" method="post" data-sv-form="{{.id}}" data-uid="{{.data.uid}}" data-format="inline" data-version="5" data-options="{{.data.options}}"
   div data-style="clean"
   ul.formkit-alert.formkit-alert-error data-element="errors" data-group="alert"
   {{ range .fields }}


### PR DESCRIPTION
instead of hard-coding them, use the frontmatter to set the uid and the
options (options will be used by the js from convertkit).
I thought this would be handled on server side but it seems not the
case, too bad. so need to set them manually.