### PR TITLE
Fix the options for convertkit form

### DIFF
--- a/content/subscribe/_index.md
+++ b/content/subscribe/_index.md
@@ -9,7 +9,7 @@ form: {
 	],
 	data: {
 		uid: "cd30502d06",
-		options: "{&quot;settings&quot;:{&quot;after_subscribe&quot;:{&quot;action&quot;:&quot;redirect&quot;,&quot;success_message&quot;:&quot;Success! Now check your email to confirm your subscription.&quot;,&quot;redirect_url&quot;:&quot;https://civicopendata.com/subscribe/survey/&quot;},&quot;modal&quot;:{&quot;trigger&quot;:null,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:null,&quot;devices&quot;:null,&quot;show_once_every&quot;:null},&quot;recaptcha&quot;:{&quot;enabled&quot;:false},&quot;return_visitor&quot;:{&quot;action&quot;:&quot;custom_content&quot;,&quot;custom_content&quot;:&quot;You already subscribed. Missing some email? Check you spam folder. &quot;},&quot;slide_in&quot;:{&quot;display_in&quot;:null,&quot;trigger&quot;:null,&quot;scroll_percentage&quot;:null,&quot;timer&quot;:null,&quot;devices&quot;:null,&quot;show_once_every&quot;:null}}}"
+		options: {"settings":{"after_subscribe":{"action":"redirect","success_message":"Success! Now check your email to confirm your subscription.","redirect_url":"https://civicopendata.com/subscribe/survey/"},"modal":{"trigger":null,"scroll_percentage":null,"timer":null,"devices":null,"show_once_every":null},"recaptcha":{"enabled":false},"return_visitor":{"action":"custom_content","custom_content":"You already subscribed. Missing some email? Check you spam folder. "},"slide_in":{"display_in":null,"trigger":null,"scroll_percentage":null,"timer":null,"devices":null,"show_once_every":null}}}
 	}
 }
 ---

--- a/layouts/partials/form.ace
+++ b/layouts/partials/form.ace
@@ -1,5 +1,5 @@
 script src="https://f.convertkit.com/ckjs/ck.5.js"
-form#ck-simple action="https://app.convertkit.com/forms/{{.id}}/subscriptions" method="post" data-sv-form="{{.id}}" data-uid="{{.data.uid}}" data-format="inline" data-version="5" data-options="{{.data.options}}"
+form#ck-simple action="https://app.convertkit.com/forms/{{.id}}/subscriptions" method="post" data-sv-form="{{.id}}" data-uid="{{.data.uid}}" data-format="inline" data-version="5" data-options="{{ .data.options | jsonify }}"
   div data-style="clean"
   ul.formkit-alert.formkit-alert-error data-element="errors" data-group="alert"
   {{ range .fields }}


### PR DESCRIPTION
convertkit does provide a wrong way of using these options. their own
script cannot parse the options with JSON.parse
therefore we use the jsonify from Hugo to convert the object into json.
now it should work, at least it worked locally